### PR TITLE
working on coroutine public api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-DS_Store
+.DS_Store
 .idea/shelf
 /confluence/target
 /dependencies/repo

--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,10 @@ repositories {
 dependencies {
     //kotlin stdlib
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.7.20")
+
+    //kotlin coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+
     testImplementation(kotlin("test"))
 }
 

--- a/src/main/kotlin/concurrency/Concurrency.kt
+++ b/src/main/kotlin/concurrency/Concurrency.kt
@@ -1,0 +1,74 @@
+package concurrency
+
+import kotlinx.coroutines.CoroutineScope
+import reactivity.Gettable
+import reactivity.Settable
+import java.util.concurrent.locks.ReentrantLock
+
+private typealias ScopedEffect = CoroutineScope.() -> Unit
+private typealias ScopedGetter<T> = CoroutineScope.() -> T
+
+private val lock = ReentrantLock()
+private var atomicEffect: ScopedEffect? = null
+
+abstract class ScopedRef<T>(
+    protected val scope: CoroutineScope,
+): Gettable<T>, CoroutineScope by scope {
+    private val subscribers = HashSet<ScopedEffect>()
+
+    protected fun <T> track() {
+        atomicEffect?.let { effect -> subscribers.add(effect) }
+    }
+
+    protected fun <T> trigger() {
+        /* TODO: de-duplicate effects */
+        subscribers.forEach { effect -> scope.effect() }
+    }
+}
+
+class ScopedMutableRef<T>(
+    scope: CoroutineScope,
+    initial: T
+): ScopedRef<T>(scope), Settable<T> {
+    private var _value = initial
+
+    override operator fun setValue(thisRef: Nothing?, property: Any?, value: T) {
+        _value = value
+        trigger<T>()
+    }
+
+    override operator fun getValue(thisRef: Nothing?, property: Any?): T {
+        track<T>()
+        return _value
+    }
+}
+
+class ScopedComputed<T>(
+    scope: CoroutineScope,
+    private val getter: ScopedGetter<T>
+): ScopedRef<T>(scope) {
+    override operator fun getValue(thisRef: Nothing?, property: Any?): T {
+        track<T>()
+        return scope.getter()
+    }
+}
+
+fun <T> CoroutineScope.ref(initial: T) = ScopedMutableRef(this, initial)
+
+fun <T> CoroutineScope.computed(getter: ScopedGetter<T>) = ScopedComputed(this, getter)
+
+fun CoroutineScope.watchEffect(update: ScopedEffect) {
+    lateinit var effect: ScopedEffect
+    effect = {
+        lock.lock()
+        try {
+            atomicEffect = effect
+            update()
+            atomicEffect = null
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    effect()
+}

--- a/src/main/kotlin/concurrency/Concurrency.kt
+++ b/src/main/kotlin/concurrency/Concurrency.kt
@@ -1,8 +1,7 @@
 package concurrency
 
 import kotlinx.coroutines.CoroutineScope
-import reactivity.Gettable
-import reactivity.Settable
+import reactivity.*
 import java.util.concurrent.locks.ReentrantLock
 
 private typealias ScopedEffect = CoroutineScope.() -> Unit
@@ -11,6 +10,14 @@ private typealias ScopedGetter<T> = CoroutineScope.() -> T
 private val lock = ReentrantLock()
 private var atomicEffect: ScopedEffect? = null
 
+/**
+ * ScopedRef provides a CoroutineScope to all reactive primitives
+ * the most primitive reactive object is a ref, it holds a single value that can only be read.
+ * a ref is a dependency that can be subscribed to. The ref will notify all subscribers when it changes.
+ * @param scope the coroutine scope to provide
+ * @see Ref
+ * @see CoroutineScope
+ */
 abstract class ScopedRef<T>(
     protected val scope: CoroutineScope,
 ): Gettable<T>, CoroutineScope by scope {
@@ -26,6 +33,13 @@ abstract class ScopedRef<T>(
     }
 }
 
+/**
+ * ScopedMutableRef is provided a CoroutineScope by ScopedRef
+ * a mutable ref is a ref that can be read and written to
+ * @param scope the coroutine scope to provide
+ * @param initial the initial value of the ref
+ * @see ScopedRef
+ */
 class ScopedMutableRef<T>(
     scope: CoroutineScope,
     initial: T
@@ -43,6 +57,15 @@ class ScopedMutableRef<T>(
     }
 }
 
+/**
+ * ScopedComputed is provided a CoroutineScope by ScopeRef
+ * a computed reactive object is a ref that is computed by a Getter
+ * @param scope the coroutine scope to provide
+ * @param getter the getter to compute on
+ * @see ScopedGetter
+ * @see ScopedRef
+ * TODO: add caching of computed values
+ */
 class ScopedComputed<T>(
     scope: CoroutineScope,
     private val getter: ScopedGetter<T>

--- a/src/test/kotlin/ReactiveCoroutineTest.kt
+++ b/src/test/kotlin/ReactiveCoroutineTest.kt
@@ -1,0 +1,38 @@
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import reactivity.computed
+import reactivity.ref
+import reactivity.watchEffect
+import kotlin.time.Duration.Companion.seconds
+
+fun main() {
+    runBlocking {
+        var quantity by ref(1000)
+        var price by ref(2.00)
+        val revenue by computed { "$%.2f".format(quantity * price) }
+
+        watchEffect {
+            println("revenue: $revenue")
+        }
+
+        quantity += 500
+        price = 1.25
+        delay(1.seconds)
+        quantity += 500
+        price = 1.25
+
+        launch {
+            watchEffect {
+                println("new price: ${"$%.2f".format(price)}")
+            }
+
+            while (true) {
+                delay(1.seconds)
+                price += .1
+            }
+
+        }
+    }
+}

--- a/src/test/kotlin/ReactiveCoroutineTest.kt
+++ b/src/test/kotlin/ReactiveCoroutineTest.kt
@@ -1,10 +1,9 @@
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import reactivity.computed
-import reactivity.ref
-import reactivity.watchEffect
+import concurrency.computed
+import concurrency.ref
+import concurrency.watchEffect
 import kotlin.time.Duration.Companion.seconds
 
 fun main() {


### PR DESCRIPTION
I have currently started working on an API that will allow you to use: 
* `ref`
* `computed`
* `watchEffect`

in a `CoroutineScope`

I'm currently facing the problem where I am unsure how I can merge the two APIs, Ideally, I would like one to be able to use the reactive primitives both freely in a `CoroutineScope` and outside of one

For now, though, I reimplemented the aforementioned reactive primitives with CoroutineScope in mind.

Two new types of effects were added:
```kotlin
typealias ScopedEffect = CoroutineScope.() -> Unit
```
```kotlin
typealias ScopedGetter<T> = CoroutineScope.() -> T
```

This allows you to compose refs and computed's out of suspendable functions.

